### PR TITLE
Add linear avoided crossing model

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,4 @@
-from .avoided_crossing_analysis import AvoidedCrossingAnalysis, avoided_crossing_direct_coupling
+from .avoided_crossing_analysis import (
+    AvoidedCrossingAnalysis,
+    avoided_crossing_direct_coupling,
+)


### PR DESCRIPTION
## Summary
- refactor `avoided_crossing_direct_coupling` to use a linear flux model
- update `AvoidedCrossingAnalysis.fit` and parameter estimation

## Testing
- `python - <<'PY'
import numpy as np
from avoided_crossing_analysis import AvoidedCrossingAnalysis, avoided_crossing_direct_coupling
flux = np.linspace(0,1,5)
frequency = np.linspace(5,7,50)
f_plus, f_minus = avoided_crossing_direct_coupling(flux, 6, 6.3, 0.5, -0.5, 0.05)

def make_peak(center):
    return np.exp(-((frequency-center)**2)/(2*0.02**2))

data = np.stack([make_peak(fp)+make_peak(fm) for fp,fm in zip(f_plus,f_minus)])
aca = AvoidedCrossingAnalysis(flux, frequency, data)
aca.find_raw_peaks(); aca.clean_peaks()
print("guess", aca.estimate_initial_params())
aca.autofit()
print("fit", aca.result.params['f_center1'].value, aca.result.params['f_center2'].value, aca.result.params['g'].value)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68831659018483249e79a53324a3a6bb